### PR TITLE
add biocViews keyword to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.0.2
+biocViews:
 Imports:
   Biobase,
   limSolve,


### PR DESCRIPTION
Installation with `install_github` fails with 

```
ERROR: dependency ‘Biobase’ is not available for package ‘BisqueRNA’
```

Adding the `biocViews` keyword to the DESCRIPTION should fix that, since it tells remotes/devtools to also search Bioconductor.